### PR TITLE
Fix CircleCI firstPush

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,52 @@ before_script: greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload
 ```
 
+## CircleCI Sample Config
+
+### yarn
+
+```yml
+# Circle 2.0
+    steps:
+      - checkout
+  
+      - run:
+          name: Install dependencies
+          command: |
+            yarn
+
+      - run:
+          name: Maybe greenkeeper update
+          command: |
+            greenkeeper-lockfile-update
+
+      - run:
+          name: Run tests
+          command: |
+            yarn test
+
+      - run:
+          name: Maybe greenkeeper upload
+          command: |
+            greenkeeper-lockfile-upload
+```
+
+```yml
+# Circle 1.0
+  dependencies:
+      override:
+        - yarn
+      post:
+        - greenkeeper-lockfile-update
+
+  test:
+    override:
+      - yarn test
+    post:
+      - greenkeeper-lockfile-upload
+```
+
+
 ## Contributing a CI Service
 
 ### Environment information

--- a/ci-services/circleci.js
+++ b/ci-services/circleci.js
@@ -9,11 +9,11 @@ const env = process.env
 function isFirstPush (branch, sha1) {
   const commitNumber = gitHelpers.getNumberOfCommitsOnBranch(branch)
   const commitMessage = gitHelpers.getCommitMessage(sha1).trim()
-  // CircleCI enviroment treats first push as 0, and also ignore the commit from greenkeeper update
-  const areFirstGreenKeeperCommits = commitNumber === 0 || commitNumber === 1
+  // CircleCI 2.0 enviroment treats first push as 0, and also ignore the commit from greenkeeper update
+  const fallsIntoCommitRange = commitNumber <= 2
 
   if (
-    areFirstGreenKeeperCommits &&
+    fallsIntoCommitRange &&
     !_.includes(config.updateMessage, commitMessage)
   ) {
     return true

--- a/ci-services/circleci.js
+++ b/ci-services/circleci.js
@@ -2,12 +2,30 @@ const _ = require('lodash')
 
 const gitHelpers = require('../lib/git-helpers')
 
+const config = require('../lib/config')
+
 const env = process.env
+
+function isFirstPush (branch, sha1) {
+  const commitNumber = gitHelpers.getNumberOfCommitsOnBranch(branch)
+  const commitMessage = gitHelpers.getCommitMessage(sha1).trim()
+  // CircleCI enviroment treats first push as 0, and also ignore the commit from greenkeeper update
+  const areFirstGreenKeeperCommits = commitNumber === 0 || commitNumber === 1
+
+  if (
+    areFirstGreenKeeperCommits &&
+    !_.includes(config.updateMessage, commitMessage)
+  ) {
+    return true
+  }
+
+  return false
+}
 
 module.exports = {
   repoSlug: `${env.CIRCLE_PROJECT_USERNAME}/${env.CIRCLE_PROJECT_REPONAME}`,
   branchName: env.CIRCLE_BRANCH,
-  firstPush: gitHelpers.getNumberOfCommitsOnBranch(env.CIRCLE_BRANCH) === 1,
+  firstPush: isFirstPush(env.CIRCLE_BRANCH, env.CIRCLE_SHA1),
   correctBuild: _.isEmpty(env.CI_PULL_REQUEST),
   uploadBuild: env.CIRCLE_NODE_INDEX === '0'
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,5 +4,8 @@ const relative = require('require-relative')
 const pkg = relative('./package.json')
 
 module.exports = _.defaults(pkg.greenkeeper, {
-  branchPrefix: 'greenkeeper/'
+  branchPrefix: 'greenkeeper/',
+  username: 'greenkeeper[bot]',
+  email: 'support@greenkeeper.io',
+  updateMessage: 'chore(package): update lockfile\n\nhttps://npm.im/greenkeeper-lockfile'
 })

--- a/lib/git-helpers.js
+++ b/lib/git-helpers.js
@@ -11,5 +11,8 @@ module.exports = {
         `git log ${branch} --oneline --not ${notArgument} | wc -l`
       ).toString()
     )
+  },
+  getCommitMessage: function getCommitMessage (sha1) {
+    return exec(`git log --format="%s" -n1 ${sha1}`).toString()
   }
 }

--- a/lib/update-lockfile.js
+++ b/lib/update-lockfile.js
@@ -1,3 +1,5 @@
+const config = require('./config')
+
 const exec = require('child_process').execSync
 
 const semver = require('semver')
@@ -49,8 +51,7 @@ module.exports = function updateLockfile (dependency, options) {
   exec('git add npm-shrinkwrap.json 2>/dev/null || true')
   exec('git add package-lock.json 2>/dev/null || true')
   exec('git add yarn.lock 2>/dev/null || true')
-  exec('git config user.email "support@greenkeeper.io"')
-  exec('git config user.name "greenkeeper[bot]"')
-  const updateMessage = 'chore(package): update lockfile\n\nhttps://npm.im/greenkeeper-lockfile'
-  exec(`git commit -m "${updateMessage}"`)
+  exec(`git config user.email "${config.email}"`)
+  exec(`git config user.name "${config.username}"`)
+  exec(`git commit -m "${config.updateMessage}"`)
 }

--- a/lib/update-lockfile.js
+++ b/lib/update-lockfile.js
@@ -25,7 +25,9 @@ module.exports = function updateLockfile (dependency, options) {
     exec('git reset HEAD')
 
     // manually reinstall the package so the lockfile is updated
-    const flag = flags[dependency.type]
+    // ignore -S for yarn since it does not exist as an option
+    const flag = options.yarn && dependency.type === 'dependencies'
+      ? '' : flags[dependency.type]
     const prefix = options.yarn
       ? setPrefixYarn(dependency.prefix)
       : `--save-prefix="${dependency.prefix}"`


### PR DESCRIPTION
Addresses #26 
1. I changed the logic of firstPush on CircleCI to account for CircleCI 1/2 environments and added a check against the commit message (which I also moved to config), since the firstPush logic runs again when it starts the upload action and a new commit is created.
2. I was getting errors when running `yarn -S` and according to the docs, this option doesn't exist, so I do a check to remove it.