### PR TITLE
Fall back to ssh key git access

### DIFF
--- a/upload.js
+++ b/upload.js
@@ -27,12 +27,12 @@ module.exports = function upload () {
   if (env.GH_TOKEN) {
     // Use the GH_TOKEN if provided.
     exec(`git remote add gk-origin https://${env.GH_TOKEN}@github.com/${info.repoSlug}`)
-    exec(`git push gk-origin HEAD:${info.branchName}`)
   } else {
     // Otherwise, assume an SSH key is available.
     exec(`git remote add gk-origin git@github.com:${info.repoSlug}`)
-    exec(`git push gk-origin HEAD:${info.branchName}`)
   }
+
+  exec(`git push gk-origin HEAD:${info.branchName}`)
 }
 
 if (require.main === module) module.exports()

--- a/upload.js
+++ b/upload.js
@@ -8,10 +8,6 @@ const info = require('./ci-services')()
 const env = process.env
 
 module.exports = function upload () {
-  if (!env.GH_TOKEN) {
-    throw new Error('Please provide a GitHub token as "GH_TOKEN" environment variable')
-  }
-
   if (!info.branchName.startsWith(config.branchPrefix)) {
     return console.error('Not a Greenkeeper branch')
   }
@@ -28,8 +24,15 @@ module.exports = function upload () {
     return console.error('Only uploading on one build job')
   }
 
-  exec(`git remote add gk-origin https://${env.GH_TOKEN}@github.com/${info.repoSlug}`)
-  exec(`git push gk-origin HEAD:${info.branchName}`)
+  if (env.GH_TOKEN) {
+    // Use the GH_TOKEN if provided.
+    exec(`git remote add gk-origin https://${env.GH_TOKEN}@github.com/${info.repoSlug}`)
+    exec(`git push gk-origin HEAD:${info.branchName}`)
+  } else {
+    // Otherwise, assume an SSH key is available.
+    exec(`git remote add gk-origin git@github.com:${info.repoSlug}`)
+    exec(`git push gk-origin HEAD:${info.branchName}`)
+  }
 }
 
 if (require.main === module) module.exports()


### PR DESCRIPTION
On Travis, the environment is automatically equipped with a deploy key. By default, the deploy key is [read-write](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys), so this works out of the box. Users always have the option of creating separate users and managing keys with user keys.

Might also make sense to require `GH_TOKEN=use_ssh` to use this functionality.