### PR TITLE
fix(circleci): use CIRCLE_PREVIOUS_BUILD_NUM to detect the first push

### DIFF
--- a/ci-services/circleci.js
+++ b/ci-services/circleci.js
@@ -1,13 +1,11 @@
 const _ = require('lodash')
 
-const gitHelpers = require('../lib/git-helpers')
-
 const env = process.env
 
 module.exports = {
   repoSlug: `${env.CIRCLE_PROJECT_USERNAME}/${env.CIRCLE_PROJECT_REPONAME}`,
   branchName: env.CIRCLE_BRANCH,
-  firstPush: gitHelpers.getNumberOfCommitsOnBranch(env.CIRCLE_BRANCH) === 1,
+  firstPush: !env.CIRCLE_PREVIOUS_BUILD_NUM,
   correctBuild: _.isEmpty(env.CI_PULL_REQUEST),
   uploadBuild: env.CIRCLE_NODE_INDEX === '0'
 }


### PR DESCRIPTION
Hey,

I think we could detect the first push on Circle CI with `!env.CIRCLE_PREVIOUS_BUILD_NUM`. I haven't tested this on Circle CI yet, though.

If it works, we wouldn't need the git tricks in #27

@ethanrubio Could you have a look at this?

Best,
Finn