### PR TITLE
chore: npm 5 is out of beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ node_js:
 - '7'
 - '6'
 - '4'
-before_install: npm i -g npm5
-install: npm5 install
+before_install: npm i -g npm@5
 before_script: node ./update.js
 after_script: node ./upload.js
-after_success: npm5 run semantic-release
+after_success: npm run semantic-release
 branches:
   except:
   - /^v\d+\.\d+\.\d+$/

--- a/README.md
+++ b/README.md
@@ -43,20 +43,9 @@ This is how it works on Travis CI for the different package managers.
 
 ```yml
 before_install:
-# It is advisable to use at least npm@4, as there are a lot of shrinkwrap fixes in there
-- npm install -g npm
+# package-lock.json was introduced in npm@5
+- npm install -g npm@5
 - npm install -g greenkeeper-lockfile@1
-before_script: greenkeeper-lockfile-update
-after_script: greenkeeper-lockfile-upload
-```
-
-### npm5 (during beta)
-
-```yml
-before_install:
-- npm i -g npm5
-- npm5 i -g greenkeeper-lockfile@1
-install: npm5 install
 before_script: greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload
 ```

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/greenkeeperio/greenkeeper-lockfile.git"
   },
   "scripts": {
-    "semantic-release": "semantic-release pre && npm5 publish && semantic-release post",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "test": "standard"
   }
 }


### PR DESCRIPTION
This removes `npm5` instructions from the docs since it is out of beta and now available as `npm@5`. It also updates our setup to use `npm`.

The `npm5` cli tool will still work though. I didn't remove support for it, since it is still maintained and used.