### PR TITLE
Fixes yarn command for updating a regular dependency.

### DIFF
--- a/lib/update-lockfile.js
+++ b/lib/update-lockfile.js
@@ -23,7 +23,10 @@ module.exports = function updateLockfile (dependency, options) {
     exec('git reset HEAD')
 
     // manually reinstall the package so the lockfile is updated
-    const flag = flags[dependency.type]
+    const flag = options.yarn && dependency.type === 'dependencies'
+      ? ''
+      : flags[dependency.type]
+
     const prefix = options.yarn
       ? setPrefixYarn(dependency.prefix)
       : `--save-prefix="${dependency.prefix}"`


### PR DESCRIPTION
The `-S` argument was either never there, or removed recently for Yarn.

I wasn unable to actually test this in the wild, since I can't get greenkeeper-lockfile to re-attempt the lockfile update because it's no longer the "first push to a new branch".  I tried rebasing and squashing commits to make it look like it was the first commit on the branch, but apparently travis still reports it as multiple commits?  I dunno...  but this should fix https://github.com/greenkeeperio/greenkeeper-lockfile/issues/28.