### PR TITLE
feat: allow package-json.lock and yarn.lock to be uppdated simultaneously, fixes #39

### DIFF
--- a/lib/update-lockfile.js
+++ b/lib/update-lockfile.js
@@ -28,19 +28,17 @@ module.exports = function updateLockfile (dependency, options) {
     exec('git revert -n HEAD')
     exec('git reset HEAD')
 
-    // manually reinstall the package so the lockfile is updated
-    const flag = options.yarn ? yarnFlags[dependency.type] : flags[dependency.type]
-    const prefix = options.yarn
-      ? setPrefixYarn(dependency.prefix)
-      : `--save-prefix="${dependency.prefix}"`
-
-    const args = `${flag} ${prefix} ${dependency.name}@${dependency.version}`
-
     if (options.yarn) {
+      const flag = yarnFlags[dependency.type]
+      const prefix = setPrefixYarn(dependency.prefix)
+      const args = `${flag} ${prefix} ${dependency.name}@${dependency.version}`
       exec(`yarn add ${args}`)
     }
 
     if (options.npm) {
+      const flag = flags[dependency.type]
+      const prefix = `--save-prefix="${dependency.prefix}"`
+      const args = `${flag} ${prefix} ${dependency.name}@${dependency.version}`
       var npmBin = 'npm'
       try {
         exec('npm5 -v')

--- a/lib/update-lockfile.js
+++ b/lib/update-lockfile.js
@@ -38,7 +38,9 @@ module.exports = function updateLockfile (dependency, options) {
 
     if (options.yarn) {
       exec(`yarn add ${args}`)
-    } else {
+    }
+
+    if (options.npm) {
       var npmBin = 'npm'
       try {
         exec('npm5 -v')

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "greenkeeper-lockfile",
   "version": "0.0.0-development",
   "lockfileVersion": 1,
+  "packageIntegrity": "sha512-i4nkYga48cXUvMoEE5k1R/H/Sh7aEnWDS5DkzD5mHPkp9fnw54O+w5eFah22LwyzqVeG6yu1GNOrD+BdYWinXA==",
   "dependencies": {
     "@semantic-release/commit-analyzer": {
       "version": "2.0.0",
@@ -2339,5 +2340,8 @@
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     }
-  }
+  },
+  "problems": [
+    "missing: underscore.string@~2.2.0rc, required by travis-ci@2.1.1"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "greenkeeper-lockfile",
   "version": "0.0.0-development",
   "lockfileVersion": 1,
-  "packageIntegrity": "sha512-i4nkYga48cXUvMoEE5k1R/H/Sh7aEnWDS5DkzD5mHPkp9fnw54O+w5eFah22LwyzqVeG6yu1GNOrD+BdYWinXA==",
   "dependencies": {
     "@semantic-release/commit-analyzer": {
       "version": "2.0.0",
@@ -2340,8 +2339,5 @@
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     }
-  },
-  "problems": [
-    "missing: underscore.string@~2.2.0rc, required by travis-ci@2.1.1"
-  ]
+  }
 }

--- a/update.js
+++ b/update.js
@@ -54,7 +54,8 @@ module.exports = function update () {
   }
 
   updateLockfile(dependency, {
-    yarn: !!yarnLock
+    yarn: !!yarnLock,
+    npm: !!packageLock
   })
 
   console.log('Lockfile updated')


### PR DESCRIPTION
This passes a new option: `npm: boolean` to `updateLockfile` to allow both `yarn.lock` and `package-json.lock` to be updated.

Sadly there is no test suite (yet) to add tests for this.  
I strongly vote for having at least unit tests. 