### PR TITLE
Fix installing regular dependencies using yarn

### DIFF
--- a/lib/update-lockfile.js
+++ b/lib/update-lockfile.js
@@ -8,6 +8,12 @@ const flags = {
   'optionalDependencies': '-O'
 }
 
+const yarnFlags = {
+  'dependencies': '',
+  'devDependencies': '-D',
+  'optionalDependencies': '-O'
+}
+
 const setPrefixYarn = prefix => prefix === '~'
   ? '--tilde'
   : prefix === ''
@@ -23,7 +29,7 @@ module.exports = function updateLockfile (dependency, options) {
     exec('git reset HEAD')
 
     // manually reinstall the package so the lockfile is updated
-    const flag = flags[dependency.type]
+    const flag = options.yarn ? yarnFlags[dependency.type] : flags[dependency.type]
     const prefix = options.yarn
       ? setPrefixYarn(dependency.prefix)
       : `--save-prefix="${dependency.prefix}"`


### PR DESCRIPTION
Since yarn doesn't accept -S when installing regular dependencies

#40 closes

I didn't see it before but this seems to be a duplicate of #34  so whichever implementation is prefered