### PR TITLE
fix: Use strict mode to fix syntax error on Node 4

### DIFF
--- a/lib/update-lockfile.js
+++ b/lib/update-lockfile.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const exec = require('child_process').execSync
 
 const semver = require('semver')


### PR DESCRIPTION
Fix error: SyntaxError: Identifier 'flag' has already been declared

Fixes #49