### PR TITLE
fix: Fix `SyntaxError: Identifier 'flag' has already been declared`

### DIFF
--- a/lib/update-lockfile.js
+++ b/lib/update-lockfile.js
@@ -35,9 +35,7 @@ module.exports = function updateLockfile (dependency, options) {
       const prefix = setPrefixYarn(dependency.prefix)
       const args = `${flag} ${prefix} ${dependency.name}@${dependency.version}`
       exec(`yarn add ${args}`)
-    }
-
-    if (options.npm) {
+    } else if (options.npm) {
       const flag = flags[dependency.type]
       const prefix = `--save-prefix="${dependency.prefix}"`
       const args = `${flag} ${prefix} ${dependency.name}@${dependency.version}`


### PR DESCRIPTION
I have faced the following issue multiple times in node 4 env:
```console
$ greenkeeper-lockfile-update

/home/travis/.config/yarn/global/node_modules/greenkeeper-lockfile/lib/update-lockfile.js:39
      const flag = flags[dependency.type]
      ^
SyntaxError: Identifier 'flag' has already been declared
    at updateLockfile (/home/travis/.config/yarn/global/node_modules/greenkeeper-lockfile/lib/update-lockfile.js:23:42)
    at Module.update [as exports] (/home/travis/.config/yarn/global/node_modules/greenkeeper-lockfile/update.js:60:3)
    at Object.<anonymous> (/home/travis/.config/yarn/global/node_modules/greenkeeper-lockfile/update.js:68:37)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:140:18)
    at node.js:1043:3

The command "greenkeeper-lockfile-update" failed and exited with 1 during .
```
- https://travis-ci.org/sudo-suhas/elastic-builder/jobs/262864973
- https://travis-ci.org/sudo-suhas/elastic-builder/jobs/264647891

This error was reported in #49 and was closed by PR #51. I don't think the issue was because of the missing `'use strict'` directive:
```
λ node --version
v4.0.0

λ echo let a = 1 > test-node4.js

λ node test-node4.js
E:\Projects\experiments\test-node4.js:1
(function (exports, require, module, __filename, __dirname) { let a = 1
                                                              ^^^
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:413:25)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:475:10)
    at startup (node.js:117:18)
    at node.js:951:3
``` 

For some reason, both `options.yarn` and `options.npm` must be truthy which leads to `flag` being declared twice. This fixes the issue with an `else if`