### PR TITLE
fix: Enable strict mode in all files

### DIFF
--- a/ci-services/circleci.js
+++ b/ci-services/circleci.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const _ = require('lodash')
 
 const env = process.env

--- a/ci-services/index.js
+++ b/ci-services/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const _ = require('lodash')
 
 const tests = require('./tests')

--- a/ci-services/jenkins.js
+++ b/ci-services/jenkins.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const env = process.env
 
 const _ = require('lodash')

--- a/ci-services/tests.js
+++ b/ci-services/tests.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const env = process.env
 
 module.exports = {

--- a/ci-services/travis.js
+++ b/ci-services/travis.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const env = process.env
 
 module.exports = {

--- a/ci-services/wercker.js
+++ b/ci-services/wercker.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const gitHelpers = require('../lib/git-helpers')
 
 const env = process.env

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const _ = require('lodash')
 const relative = require('require-relative')
 

--- a/lib/extract-dependency.js
+++ b/lib/extract-dependency.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const _ = require('lodash')
 
 module.exports = function extractDependency (pkg, branchPrefix, branch) {

--- a/lib/git-helpers.js
+++ b/lib/git-helpers.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const exec = require('child_process').execSync
 
 const _ = require('lodash')


### PR DESCRIPTION
Right now, only a few files have the `'use strict'` directive. I am not entirely sure why this isn't resulting in error like the following:
```
λ node --version
v4.0.0

λ echo let a = 1 > test-node4.js

λ node test-node4.js
E:\Projects\experiments\test-node4.js:1
(function (exports, require, module, __filename, __dirname) { let a = 1
                                                              ^^^
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:413:25)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:475:10)
    at startup (node.js:117:18)
    at node.js:951:3
``` 

This enables strict mode in all js files.