### PR TITLE
feat: allow to configure build leader id via env variable

### DIFF
--- a/ci-services/circleci.js
+++ b/ci-services/circleci.js
@@ -7,5 +7,5 @@ module.exports = {
   branchName: env.CIRCLE_BRANCH,
   firstPush: !env.CIRCLE_PREVIOUS_BUILD_NUM,
   correctBuild: _.isEmpty(env.CI_PULL_REQUEST),
-  uploadBuild: env.CIRCLE_NODE_INDEX === '0'
+  uploadBuild: env.CIRCLE_NODE_INDEX === `${env.BUILD_LEADER_ID || 0}`
 }

--- a/ci-services/travis.js
+++ b/ci-services/travis.js
@@ -11,5 +11,5 @@ module.exports = {
   // Is this a regular build
   correctBuild: env.TRAVIS_PULL_REQUEST === 'false',
   // Should the lockfile be uploaded from this build
-  uploadBuild: env.TRAVIS_JOB_NUMBER.endsWith('.1')
+  uploadBuild: env.TRAVIS_JOB_NUMBER.endsWith(`.${env.BUILD_LEADER_ID || 1}`)
 }


### PR DESCRIPTION
Use environment variable `BUILD_LEADER_ID`, if set, to determine the build leader. Allow to run `greenkeeper-lockfile-upload` on a specific Node version or Travis stage.

Similar to [travis-deploy-once/index.js#L49](https://github.com/semantic-release/travis-deploy-once/blob/9dadfd157e6b01ca48fe71a885d091fcb341431c/index.js#L49)