### PR TITLE
fix: discard changes in package.json before committing

### DIFF
--- a/lib/update-lockfile.js
+++ b/lib/update-lockfile.js
@@ -48,6 +48,8 @@ module.exports = function updateLockfile (dependency, options) {
       } catch (err) {}
 
       exec(`${npmBin} install ${args}`)
+      // discard any accidental changes in package.json
+      exec('git checkout -- package.json')
     }
   }
 


### PR DESCRIPTION
This fixes a crash when a package.json has devDependencies that are not sorted alphabetically. `npm install --save-dev` sorts dependencies in the package.json, so when a lockfile is not changed by this script, it tries to commit nothing, which fails.

*Note*: this only affects versions of npm where devDependencies are not shrinkwrapped, such as npm 3.

Example case: the `package.json` has the following devDependencies:

``` json
{
  "devDependencies": {
    "typescript": "^2.4.2",
    "jest": "^21.0.1",
    "ts-jest": "^20.0.0"
  }
}
```

Let's say `ts-jest` gets updated to 21.0.0. Greenkeeper would create a new commit where just the version in the `package.json` is updated and the `greenkeeper-lockfile-update` script is triggered. This:

- Reverts the greenkeeper commit using `git revert -n HEAD`
- Unstages the `package.json` using `git reset HEAD`
- Updates the shrinkwrap using `npm install --save-dev ts-jest@21.0.0`

Now, the following happens:

- `git status --porcelain` contains `M package.json` due to the sorting mentioned above, so the script does not return
- `git add npm-shrinkwrap.json`, `git add package-lock.json` and `git add yarn.lock.json` results in no staged changes
- `git commit` exits with non-zero.