### PR TITLE
fix: Jenkins CI fix

### DIFF
--- a/ci-services/jenkins.js
+++ b/ci-services/jenkins.js
@@ -5,7 +5,7 @@ const gitHelpers = require('../lib/git-helpers')
 
 module.exports = {
   gitUrl: env.GIT_URL,
-  branchName: _.drop(_.split(env.GIT_BRANCH, '/')).join('/'),
+  branchName: env.GIT_BRANCH,
   firstPush: gitHelpers.getNumberOfCommitsOnBranch(env.GIT_BRANCH) === 1,
   correctBuild: true, // assuming pull requests are not build
   uploadBuild: true // assuming 1 build per branch

--- a/ci-services/jenkins.js
+++ b/ci-services/jenkins.js
@@ -1,6 +1,4 @@
 const env = process.env
-
-const _ = require('lodash')
 const gitHelpers = require('../lib/git-helpers')
 
 module.exports = {


### PR DESCRIPTION
The `branchName` requires the `greenkeeper/` prefix in order to continue.

This continually fails on Jenkins with the message below when trying to setup Greenkeeper (branch name being `greenkeeper/initial`)
> initial is not a Greenkeeper branch

https://github.com/greenkeeperio/greenkeeper-lockfile/blob/3f8726855da777f8caf66e50b7ec5af6a2774468/update.js#L46-L48

I'm updating `branchName` so that it no longer strips the prefix. This aligns the Jenkins implementation with the other CI services

https://github.com/greenkeeperio/greenkeeper-lockfile/blob/3f8726855da777f8caf66e50b7ec5af6a2774468/ci-services/travis.js#L7
https://github.com/greenkeeperio/greenkeeper-lockfile/blob/3f8726855da777f8caf66e50b7ec5af6a2774468/ci-services/circleci.js#L7

