### PR TITLE
fix(yarn): preserve caret ranges

### DIFF
--- a/lib/update-lockfile.js
+++ b/lib/update-lockfile.js
@@ -16,12 +16,6 @@ const yarnFlags = {
   'optionalDependencies': ' -O'
 }
 
-const setPrefixYarn = prefix => prefix === '~'
-  ? ' --tilde'
-  : prefix === ''
-  ? ' --exact'
-  : ''
-
 module.exports = function updateLockfile (dependency, options) {
   if (!options.yarn && semver.lt(exec('npm --version').toString().trim(), '3.0.0')) {
     exec('npm shrinkwrap')
@@ -32,9 +26,8 @@ module.exports = function updateLockfile (dependency, options) {
 
     if (options.yarn) {
       const flag = yarnFlags[dependency.type]
-      const prefix = setPrefixYarn(dependency.prefix)
       const envArgs = process.env.GK_LOCK_YARN_OPTS ? ` ${process.env.GK_LOCK_YARN_OPTS.trim()}` : ''
-      const args = `${flag}${prefix}${envArgs} ${dependency.name}@${dependency.version}`
+      const args = `${flag}${envArgs} '${dependency.name}@${dependency.range}'`
       exec(`yarn add${args}`)
     }
 

--- a/test/lib/update-lockfile.js
+++ b/test/lib/update-lockfile.js
@@ -8,7 +8,8 @@ const dependency = {
   type: 'dependencies',
   name: 'my-dependency',
   version: '1.0.0',
-  prefix: ''
+  prefix: '',
+  range: '1.0.0'
 }
 
 const prepare = () => {
@@ -29,7 +30,7 @@ test('use yarn', t => {
   t.plan(1)
   exec.withArgs('npm --version').returns('3.0.0')
   updateLockfile(dependency, { yarn: true })
-  t.ok(exec.thirdCall.calledWith('yarn add --exact my-dependency@1.0.0'))
+  t.ok(exec.thirdCall.calledWith("yarn add 'my-dependency@1.0.0'"))
 })
 
 test('yarn no prefix', t => {
@@ -41,7 +42,7 @@ test('yarn no prefix', t => {
   exec.withArgs('npm --version').returns('3.0.0')
   exec.withArgs('npm5 -v').throws()
   updateLockfile(tildeDep, { yarn: true })
-  t.ok(exec.thirdCall.calledWith('yarn add my-dependency@1.0.0'))
+  t.ok(exec.thirdCall.calledWith("yarn add 'my-dependency@1.0.0'"))
 })
 
 test('use yarn with extra arguments from ENV', t => {
@@ -50,7 +51,7 @@ test('use yarn with extra arguments from ENV', t => {
   process.env.GK_LOCK_YARN_OPTS = '--ignore-engines'
   exec.withArgs('npm --version').returns('3.0.0')
   updateLockfile(dependency, { yarn: true })
-  t.ok(exec.thirdCall.calledWith('yarn add --exact --ignore-engines my-dependency@1.0.0'))
+  t.ok(exec.thirdCall.calledWith("yarn add --ignore-engines 'my-dependency@1.0.0'"))
   delete process.env.GK_LOCK_YARN_OPTS
 })
 
@@ -76,12 +77,13 @@ test('tilde prefix', t => {
   prepare()
   t.plan(2)
   const tildeDep = Object.assign({}, dependency, {
-    prefix: '~'
+    prefix: '~',
+    range: '~1.0.0'
   })
   exec.withArgs('npm --version').returns('3.0.0')
   exec.withArgs('npm5 -v').throws()
   updateLockfile(tildeDep, { yarn: true, npm: true })
-  t.ok(exec.thirdCall.calledWith('yarn add --tilde my-dependency@1.0.0'))
+  t.ok(exec.thirdCall.calledWith("yarn add 'my-dependency@~1.0.0'"))
   t.ok(exec.getCall(4).calledWith('npm install -S --save-prefix="~" my-dependency@1.0.0'))
 })
 


### PR DESCRIPTION
Currently, the lockfile commit for a dependency that is declared with a caret (`^`) in `package.json` writes an exact version into `yarn.lock`.
This means that when checking out the branch and running `yarn` to install the dependencies, `yarn.lock` will be modified again, leaving the repo in an unclean state:
```
-"@types/karma@1.7.0":
+"@types/karma@^1.7.0":
```

This PR fixes that by specifying the dependency's version range instead of the `--exact` / `--tilde` switches when installing via yarn.
I've tested it on one of my repos with exact, tilde and caret ranges and the lockfile commit always used the correct prefix, resulting in a stable lockfile state.

Please do tell me if I`m missing something that makes using the switches necessary, they seemed like an overly complex way of performing the install to me.