### PR TITLE
Fix completely broken shrinkwrap support

### DIFF
--- a/update.js
+++ b/update.js
@@ -53,7 +53,7 @@ module.exports = function update () {
 
   updateLockfile(dependency, {
     yarn: yarnLockExists,
-    npm: packageLockExists
+    npm: packageLockExists || shrinkwrapExists
   })
 
   console.log('Lockfile updated')


### PR DESCRIPTION
Lately, **all** Greenkeeper builds of our projects using `npm-shrinkwrap.json` have been failing due to a regression in `update.js`, because neither the `yarn install` or `npm install` step is executed, resulting in this script to try to commit nothing:

```
$ greenkeeper-lockfile-update
child_process.js:524
    throw err;
    ^
Error: Command failed: git commit -m "chore(package): update lockfile
https://npm.im/greenkeeper-lockfile"
    at checkExecSyncError (child_process.js:481:13)
    at execSync (child_process.js:521:13)
    at updateLockfile (/home/travis/.nvm/versions/node/v6.11.1/lib/node_modules/greenkeeper-lockfile/lib/update-lockfile.js:63:3)
    at Module.update [as exports] (/home/travis/.nvm/versions/node/v6.11.1/lib/node_modules/greenkeeper-lockfile/update.js:60:3)
    at Object.<anonymous> (/home/travis/.nvm/versions/node/v6.11.1/lib/node_modules/greenkeeper-lockfile/update.js:68:37)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
```