### PR TITLE
docs: show how to skip npm latest in travis example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This is how it works on Travis CI for the different package managers.
 ```yml
 before_install:
 # package-lock.json was introduced in npm@5
-- npm install -g npm@5 # skip this if you are using node 9
+- '[[ $(node -v) =~ ^v9.*$ ]] || npm install -g npm@latest' # skipped when using node 9
 - npm install -g greenkeeper-lockfile@1
 before_script: greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload


### PR DESCRIPTION
Instead of just mentioning that `npm install -g npm@latest` should be skipped, let's show folks how they can do that.

This example has been tested and verified here: https://github.com/sywac/sywac/blob/51fe43e74740d29e9ad7c87aa593c16ee07307b2/.travis.yml#L8