### PR TITLE
fix(ci-test): fix env test for bitrise

### DIFF
--- a/ci-services/tests.js
+++ b/ci-services/tests.js
@@ -9,5 +9,5 @@ module.exports = {
   travis: () => env.TRAVIS === 'true',
   wercker: () => env.WERCKER === 'true',
   codeship: () => env.CI_NAME === 'codeship',
-  bitrise: () => env.CI === 'true' && env.BITRISE_BUILD_NUMBER !== ''
+  bitrise: () => env.CI === 'true' && env.BITRISE_BUILD_NUMBER !== undefined
 }


### PR DESCRIPTION
Comparing to an empty string doesn't work because the env var will be undefined on other CI systems and therefore return true.