### PR TITLE
Fix firstPush when uploading lockfiles as part of a Circle 2.0 workflow

### DIFF
--- a/ci-services/circleci.js
+++ b/ci-services/circleci.js
@@ -1,13 +1,14 @@
 'use strict'
 
 const _ = require('lodash')
+const gitHelpers = require('../lib/git-helpers')
 
 const env = process.env
 
 module.exports = {
   repoSlug: `${env.CIRCLE_PROJECT_USERNAME}/${env.CIRCLE_PROJECT_REPONAME}`,
   branchName: env.CIRCLE_BRANCH,
-  firstPush: !env.CIRCLE_PREVIOUS_BUILD_NUM,
+  firstPush: gitHelpers.getNumberOfCommitsOnBranch(env.CIRCLE_BRANCH) === 1,
   correctBuild: _.isEmpty(env.CI_PULL_REQUEST),
   uploadBuild: env.CIRCLE_NODE_INDEX === `${env.BUILD_LEADER_ID || 0}`
 }


### PR DESCRIPTION
Circle 2.0 workflows specify `CIRCLE_PREVIOUS_BUILD_NUM` for builds _in the same workflow_, so it's unfortunately pretty useless in that case

---

Example build where it was failing previously: https://circleci.com/gh/convoyinc/apollo-cache-hermes/3368
Notice that build 3367 (`$CIRCLE_PREVIOUS_BUILD_NUM`) is part of the same workflow: https://circleci.com/workflow-run/f51c1998-e980-4b4c-9a1f-ebdc2b917419