### PR TITLE
fix: Use build number from env on Jenkins

### DIFF
--- a/ci-services/jenkins.js
+++ b/ci-services/jenkins.js
@@ -8,7 +8,7 @@ const gitHelpers = require('../lib/git-helpers')
 module.exports = {
   gitUrl: env.GIT_URL,
   branchName: _.drop(_.split(env.GIT_BRANCH, '/')).join('/'),
-  firstPush: gitHelpers.getNumberOfCommitsOnBranch(env.GIT_BRANCH) === 1,
+  firstPush: env.BUILD_NUMBER === '1' || gitHelpers.getNumberOfCommitsOnBranch(env.GIT_BRANCH) === 1,
   correctBuild: true, // assuming pull requests are not build
   uploadBuild: true // assuming 1 build per branch
 }


### PR DESCRIPTION
Seems like #73 has gone stale. This uses the environment variable.