### PR TITLE
feat: add team city support

### DIFF
--- a/ci-services/teamcity.js
+++ b/ci-services/teamcity.js
@@ -1,0 +1,35 @@
+const gitHelpers = require('../lib/git-helpers')
+
+const env = process.env
+
+/**
+ * In order for this to work with Team City, the build configuration needs to set
+ * the following environment variables:
+ *
+ * - VCS_ROOT_URL from the vcsroot.<vcsrootid>.url parameter
+ * - VCS_ROOT_BRANCH from the teamcity.build.branch parameter
+ */
+
+/**
+ * Is the current branch a pull request
+ */
+function isPullRequest () {
+  return /.+\/merge|head/.test(env.VCS_ROOT_BRANCH)
+}
+
+/**
+ * Should the lockfile be uploaded
+ */
+function shouldUpload () {
+  const re = /^(chore|fix)\(package\): update lockfile|([^ ]+ to version).*$/mi
+  const lastCommitMessage = gitHelpers.getLastCommitMessage()
+  return re.test(lastCommitMessage)
+}
+
+module.exports = {
+  repoSlug: gitHelpers.getRepoSlug(env.VCS_ROOT_URL),
+  branchName: env.VCS_ROOT_BRANCH,
+  firstPush: shouldUpload(),
+  correctBuild: !isPullRequest(),
+  uploadBuild: shouldUpload()
+}

--- a/ci-services/tests.js
+++ b/ci-services/tests.js
@@ -10,5 +10,6 @@ module.exports = {
   wercker: () => env.WERCKER === 'true',
   codeship: () => env.CI_NAME === 'codeship',
   bitrise: () => env.CI === 'true' && env.BITRISE_BUILD_NUMBER !== undefined,
-  semaphoreci: () => env.SEMAPHORE === 'true'
+  semaphoreci: () => env.SEMAPHORE === 'true',
+  teamcity: () => env.TEAMCITY_VERSION !== undefined
 }

--- a/lib/git-helpers.js
+++ b/lib/git-helpers.js
@@ -14,6 +14,9 @@ module.exports = {
       ).toString()
     )
   },
+  getLastCommitMessage: function getLastCommitMessage () {
+    return exec('git log --format=%B -1').toString()
+  },
   getRepoSlug: function getRepoSlug (githubUrl) {
     var ghRegex = /\S+[:|/](\w+(?:[-]\w+)*)\/(\w+(?:[-]\w+)*)/g
     var parsed = ghRegex.exec(githubUrl)


### PR DESCRIPTION
This PR adds support for Team City. 

Team City has all the build related information in certain configuration parameters, but in order to make them available to `greenkeeper-lockfile`, they need to be manually mapped to environment variables in the build configuration.

This PR assumes that these two variables are available to the script:

* `VCS_ROOT_URL` which is mapped to the `vcsroot.<vcsrootid>.url` parameter
* `VCS_ROOT_BRANCH` which is mapped to the `teamcity.build.branch` parameter

The `GH_TOKEN` environment variable also needs to be defined, but that needs to happen independently of the CI server.

In order to detect if builds are coming from a PR or not, we can check the name of the branch. If it ends with `/merge` or `/head`, it means it is  a pull request according to this [post](https://blog.jetbrains.com/teamcity/2013/02/automatically-building-pull-requests-from-github-with-teamcity/).

In order to set the `firstPush` and `correctBuild` flags correctly I copied the logic from the Codeship implementation. Unlike Codeship, Team City does not provide any parameter to access the commit message, so I added a function in `gitHelpers` to do that.

Edit: I just realized that https://github.com/greenkeeperio/greenkeeper-lockfile/pull/106 is also trying to add support to Team City. I hadn't seen it until I created the PR. There are some differences between both PRs. I'm happy to close this PR if the other path is preferred. Sorry for the noise.