### PR TITLE
Bitrise now sets BITRISE_IO

### DIFF
--- a/ci-services/tests.js
+++ b/ci-services/tests.js
@@ -9,7 +9,7 @@ module.exports = {
   travis: () => env.TRAVIS === 'true',
   wercker: () => env.WERCKER === 'true',
   codeship: () => env.CI_NAME === 'codeship',
-  bitrise: () => env.CI === 'true' && env.BITRISE_BUILD_NUMBER !== undefined,
+  bitrise: () => env.BITRISE_IO === 'true',
   semaphoreci: () => env.SEMAPHORE === 'true',
   teamcity: () => env.TEAMCITY_VERSION !== undefined
 }


### PR DESCRIPTION
Bitrise now sets `BITRISE_IO = true` to indicate the build is running on bitrise.io. This variable is not set by the Bitrise CLI. Other CI services, such as [CircleCI](https://circleci.com/docs/2.0/env-vars/#general-environment-variables), also set `CI = true`, which makes the `CI` enviornment variable unreliable.  `BITRISE_BUILD_NUMBER` is the build number on bitrise.io and should no longer be necessary.

https://devcenter.bitrise.io/faq/available-environment-variables/
More information here: https://github.com/bitrise-io/bitrise/issues/591