### PR TITLE
feat: circleci workflow support for 2.0.0 (monorepos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,10 @@ after_script: greenkeeper-lockfile-upload
 
 ## CircleCI workflows
 
-In order to use `greenkeeper-lockfile` with CircleCI workflows, it must be in the first job run. Use [sequential job execution](https://circleci.com/docs/2.0/workflows/#sequential-job-execution-example) to ensure the job that runs `greenkeeper-lockfile` is always executed first. For example, if `greenkeeper-lockfile` is run in the `lockfile` job, all other jobs in the workflow must require the `lockfile` job to finish before running:
+In order to use `greenkeeper-lockfile` with CircleCI workflows, `greenkeeper-lockfile-update` must be run in the first job, while `greenkeeper-lockfile-upload` can be run in any job.
+If you want to upload the lockfile in a later job, the `.git` directory needs to be saved to cache after updating, and restored before uploading. ([example workflow config](https://github.com/patkub/test-greenkeeper-lockfile-circleci-first-push/blob/master/.circleci/config.yml))
+Use [sequential job execution](https://circleci.com/docs/2.0/workflows/#sequential-job-execution-example) to ensure the job that runs `greenkeeper-lockfile-update` is always executed first.
+For example, if `greenkeeper-lockfile-update` is run in the `lockfile` job, all other jobs in the workflow must require the `lockfile` job to finish before running:
 
 ```yml
 workflows:

--- a/ci-services/circleci.js
+++ b/ci-services/circleci.js
@@ -1,12 +1,24 @@
 'use strict'
 
 const _ = require('lodash')
+const gitHelpers = require('../lib/git-helpers')
 
 const env = process.env
+
+/**
+ * Last commit is a lockfile update
+ */
+function isLockfileUpdate () {
+  const reUpdateLockfile = /^chore\(package\): update lockfiles*$/mi
+  const lastCommitMessage = gitHelpers.getLastCommitMessage()
+  return reUpdateLockfile.test(lastCommitMessage)
+}
 
 module.exports = {
   repoSlug: `${env.CIRCLE_PROJECT_USERNAME}/${env.CIRCLE_PROJECT_REPONAME}`,
   branchName: env.CIRCLE_BRANCH,
-  correctBuild: _.isEmpty(env.CI_PULL_REQUEST),
-  uploadBuild: env.CIRCLE_NODE_INDEX === `${env.BUILD_LEADER_ID || 0}`
+  // update, CIRCLE_PREVIOUS_BUILD_NUM is only null on the first job of the first workflow on the branch
+  correctBuild: _.isEmpty(env.CI_PULL_REQUEST) && !env.CIRCLE_PREVIOUS_BUILD_NUM,
+  // upload when last commit is lockfile update
+  uploadBuild: env.CIRCLE_NODE_INDEX === `${env.BUILD_LEADER_ID || 0}` && isLockfileUpdate()
 }


### PR DESCRIPTION
This adds support to use greenkeeper-lockfile in CircleCI workflows.

Successful builds: https://circleci.com/gh/patkub/test-greenkeeper-lockfile-circleci-first-push/tree/greenkeeper%2Ftest-greenkeeper-lockfile-appveyor-package-1.0.73
On the initial greenkeeper commit, the lockfile gets [updated](https://circleci.com/gh/patkub/test-greenkeeper-lockfile-circleci-first-push/188) and [uploaded](https://circleci.com/gh/patkub/test-greenkeeper-lockfile-circleci-first-push/190). On the "chore(package): update lockfiles" commit [update](https://circleci.com/gh/patkub/test-greenkeeper-lockfile-circleci-first-push/191) and [upload](https://circleci.com/gh/patkub/test-greenkeeper-lockfile-circleci-first-push/193) succeed.

Workflow support for 1.0.0 (with firstPush) is implemented in https://github.com/patkub/greenkeeper-lockfile/tree/circleci-firstpush-v1 if it's still of interest.
Old PR: https://github.com/greenkeeperio/greenkeeper-lockfile/pull/143