### PR TITLE
fix: team city update lockfile(s) plural commit message regex

### DIFF
--- a/ci-services/teamcity.js
+++ b/ci-services/teamcity.js
@@ -21,7 +21,7 @@ function isPullRequest () {
  * Should the lockfile be uploaded
  */
 function shouldUpload () {
-  const re = /^(chore|fix)\(package\): update lockfile|([^ ]+ to version).*$/mi
+  const re = /^(chore|fix)\(package\): update lockfiles*|([^ ]+ to version).*$/mi
   const lastCommitMessage = gitHelpers.getLastCommitMessage()
   return re.test(lastCommitMessage)
 }


### PR DESCRIPTION
Update lockfile now commits with "lockfile" or "lockfiles" depending on how many files are changed.
https://github.com/greenkeeperio/greenkeeper-lockfile/blob/master/lib/update-lockfile.js#L66-L73

#164 