### PR TITLE
fix: compare lease against proper remote

### DIFF
--- a/upload.js
+++ b/upload.js
@@ -54,7 +54,7 @@ module.exports = function upload () {
   const err = fs.openSync('gk-lockfile-git-push.err', 'w')
 
   exec(`git remote add gk-origin ${remote} || git remote set-url gk-origin ${remote}`)
-  exec(`git push${process.env.GK_LOCK_COMMIT_AMEND ? ' --force-with-lease' : ''} gk-origin HEAD:${info.branchName}`, {
+  exec(`git push${process.env.GK_LOCK_COMMIT_AMEND ? ` --force-with-lease=${info.branchName}:origin/${info.branchName}` : ''} gk-origin HEAD:${info.branchName}`, {
     stdio: [
       'pipe',
       'pipe',


### PR DESCRIPTION
fixes #174 

as mentioned [in the issue thread](https://github.com/greenkeeperio/greenkeeper-lockfile/issues/174#issuecomment-401680470), i used the [suggestion](https://github.com/greenkeeperio/greenkeeper-lockfile/issues/174#issuecomment-400363829) from @richardson-trevor and verified that it worked properly in [this PR](https://github.com/travi/scaffolder-sub-command/pull/72)

this PR is not enough to get the amend feature working, but does fix the inability to force push after amending. i think it comes down to your call whether this should be merged before fixing the resulting looping of builds mentioned [in the issue thread](https://github.com/greenkeeperio/greenkeeper-lockfile/issues/174#issuecomment-401680470)