### PR TITLE
fix(hasLockfileCommit): specify origin when fetching

### DIFF
--- a/lib/git-helpers.js
+++ b/lib/git-helpers.js
@@ -31,7 +31,7 @@ module.exports = {
     // console.log(`git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*`)
     exec(`git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*`)
     // console.log(`git fetch`)
-    exec(`git fetch`)
+    exec(`git fetch gk-origin`)
     // console.log(`git checkout master`)
     // Sometimes weird things happen with Git, so let's make sure that we have a clean
     // working tree before we go in!

--- a/test/__snapshots__/update.js.snap
+++ b/test/__snapshots__/update.js.snap
@@ -3,7 +3,7 @@
 exports[`monorepo: no package.json 1`] = `
 Array [
   "git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*",
-  "git fetch",
+  "git fetch gk-origin",
   "git stash",
   "git checkout master",
   "git log --oneline origin/greenkeeper/my-dependency-1.0.0...master | grep 'chore(package): update lockfile'",
@@ -14,7 +14,7 @@ Array [
 exports[`monorepo: no root and one sub package 1`] = `
 Array [
   "git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*",
-  "git fetch",
+  "git fetch gk-origin",
   "git stash",
   "git checkout master",
   "git log --oneline origin/greenkeeper/my-dependency-1.0.0...master | grep 'chore(package): update lockfile'",
@@ -39,7 +39,7 @@ https://npm.im/greenkeeper-lockfile\\"",
 exports[`monorepo: no root and two sub package 1`] = `
 Array [
   "git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*",
-  "git fetch",
+  "git fetch gk-origin",
   "git stash",
   "git checkout master",
   "git log --oneline origin/greenkeeper/my-dependency-1.0.0...master | grep 'chore(package): update lockfile'",
@@ -71,7 +71,7 @@ https://npm.im/greenkeeper-lockfile\\"",
 exports[`monorepo: no root and two sub package at different levels 1`] = `
 Array [
   "git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*",
-  "git fetch",
+  "git fetch gk-origin",
   "git stash",
   "git checkout master",
   "git log --oneline origin/greenkeeper/my-dependency-1.0.0...master | grep 'chore(package): update lockfile'",
@@ -103,7 +103,7 @@ https://npm.im/greenkeeper-lockfile\\"",
 exports[`monorepo: root and one sub package 1`] = `
 Array [
   "git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*",
-  "git fetch",
+  "git fetch gk-origin",
   "git stash",
   "git checkout master",
   "git log --oneline origin/greenkeeper/my-dependency-1.0.0...master | grep 'chore(package): update lockfile'",
@@ -135,7 +135,7 @@ https://npm.im/greenkeeper-lockfile\\"",
 exports[`monorepo: root and two sub package 1`] = `
 Array [
   "git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*",
-  "git fetch",
+  "git fetch gk-origin",
   "git stash",
   "git checkout master",
   "git log --oneline origin/greenkeeper/my-dependency-1.0.0...master | grep 'chore(package): update lockfile'",
@@ -174,7 +174,7 @@ https://npm.im/greenkeeper-lockfile\\"",
 exports[`monorepo: root and two sub package at different levels 1`] = `
 Array [
   "git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*",
-  "git fetch",
+  "git fetch gk-origin",
   "git stash",
   "git checkout master",
   "git log --oneline origin/greenkeeper/my-dependency-1.0.0...master | grep 'chore(package): update lockfile'",
@@ -213,7 +213,7 @@ https://npm.im/greenkeeper-lockfile\\"",
 exports[`monorepo: root package 1`] = `
 Array [
   "git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*",
-  "git fetch",
+  "git fetch gk-origin",
   "git stash",
   "git checkout master",
   "git log --oneline origin/greenkeeper/my-dependency-1.0.0...master | grep 'chore(package): update lockfile'",


### PR DESCRIPTION
There is more context in https://github.com/greenkeeperio/greenkeeper-lockfile/issues/164#issuecomment-405308480

When configuring the remote to use `GH_TOKEN` in `upload.js` it is only done for the `gk-origin` remote, but then in `git-helpers#hasLockfileCommit` a `git fetch` is done, which can fail if there is a `origin` remote defined, as this one is not configured with `GH_TOKEN`.

This PR updates `hasLockfileCommit` to make the fetch from `gk-origin`.