### PR TITLE
feat: Add GitLab-CI

### DIFF
--- a/ci-services/gitlab.js
+++ b/ci-services/gitlab.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const env = process.env
+
+module.exports = {
+  repoSlug: env.CI_PROJECT_PATH_SLUG,
+  branchName: env.CI_COMMIT_REF_NAME,
+  correctBuild: /^greenkeeper\/.+/.test(env.CI_COMMIT_REF_NAME),
+  uploadBuild: true
+}

--- a/ci-services/tests.js
+++ b/ci-services/tests.js
@@ -15,5 +15,6 @@ module.exports = {
   semaphoreci: () => env.SEMAPHORE === 'true',
   teamcity: () => env.TEAMCITY_VERSION !== undefined,
   appveyor: () => env.APPVEYOR === 'True' || env.APPVEYOR === 'true',
+  gitlab: () => env.GITLAB_CI === 'true',
   buddyworks: () => env.BUDDY_EXECUTION_ID !== undefined
 }


### PR DESCRIPTION
This allows the usage of Greenkeeper.io with GitLab CI/CD for GitHub (https://about.gitlab.com/solutions/github/).