### PR TITLE
fix: repoSlug for GitLab CI

### DIFF
--- a/ci-services/gitlab.js
+++ b/ci-services/gitlab.js
@@ -3,7 +3,7 @@
 const env = process.env
 
 module.exports = {
-  repoSlug: env.CI_PROJECT_PATH_SLUG,
+  repoSlug: env.CI_PROJECT_PATH,
   branchName: env.CI_COMMIT_REF_NAME,
   correctBuild: /^greenkeeper\/.+/.test(env.CI_COMMIT_REF_NAME),
   uploadBuild: true

--- a/lib/git-helpers.js
+++ b/lib/git-helpers.js
@@ -43,13 +43,8 @@ module.exports = {
     )
   },
   hasLockfileCommit: function hasLockfileCommit (info) {
-    DEBUG && console.log('At the begin of hasLockfileCommit, about to call setupRemote')
-
     setupRemote(info)
-    
-    DEBUG && console.log('in hasLockfileCommit, right after call to setupRemote')
-    
-    const defaultBranch = process.env.GK_LOCK_DEFAULT_BRANCH || 'origin/master'
+    const defaultBranch = process.env.GK_LOCK_DEFAULT_BRANCH || 'master'
     // CI clones are often shallow clones. Let’s make sure we have enough to work with
     // https://stackoverflow.com/a/44036486/242298
     // console.log(`git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*`)
@@ -60,9 +55,6 @@ module.exports = {
     // Sometimes weird things happen with Git, so let's make sure that we have a clean
     // working tree before we go in!
     exec(`git stash`)
-
-    DEBUG && console.log('right before git checkout ' + defaultBranch + ', fails with multiple origins')
-    
     exec(`git checkout ${defaultBranch}`)
 
     DEBUG && console.log('sucessfully funged the git repo, so we can diff this branch against the default branch')

--- a/lib/git-helpers.js
+++ b/lib/git-helpers.js
@@ -43,7 +43,12 @@ module.exports = {
     )
   },
   hasLockfileCommit: function hasLockfileCommit (info) {
+    DEBUG && console.log('At the begin of hasLockfileCommit, about to call setupRemote')
+
     setupRemote(info)
+    
+    DEBUG && console.log('in hasLockfileCommit, right after call to setupRemote')
+    
     const defaultBranch = process.env.GK_LOCK_DEFAULT_BRANCH || 'master'
     // CI clones are often shallow clones. Let’s make sure we have enough to work with
     // https://stackoverflow.com/a/44036486/242298
@@ -55,6 +60,9 @@ module.exports = {
     // Sometimes weird things happen with Git, so let's make sure that we have a clean
     // working tree before we go in!
     exec(`git stash`)
+
+    DEBUG && console.log(`right before git checkout ${defaultBranch}`)
+    
     exec(`git checkout ${defaultBranch}`)
 
     DEBUG && console.log('sucessfully funged the git repo, so we can diff this branch against the default branch')

--- a/lib/git-helpers.js
+++ b/lib/git-helpers.js
@@ -61,7 +61,7 @@ module.exports = {
     // working tree before we go in!
     exec(`git stash`)
 
-    DEBUG && console.log(`right before git checkout ${defaultBranch}`)
+    DEBUG && console.log('right before git checkout ' + defaultBranch + 'fails with multiple origins')
     
     exec(`git checkout ${defaultBranch}`)
 

--- a/lib/git-helpers.js
+++ b/lib/git-helpers.js
@@ -49,7 +49,7 @@ module.exports = {
     
     DEBUG && console.log('in hasLockfileCommit, right after call to setupRemote')
     
-    const defaultBranch = process.env.GK_LOCK_DEFAULT_BRANCH || 'master'
+    const defaultBranch = process.env.GK_LOCK_DEFAULT_BRANCH || 'origin/master'
     // CI clones are often shallow clones. Let’s make sure we have enough to work with
     // https://stackoverflow.com/a/44036486/242298
     // console.log(`git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*`)
@@ -61,7 +61,7 @@ module.exports = {
     // working tree before we go in!
     exec(`git stash`)
 
-    DEBUG && console.log('right before git checkout ' + defaultBranch + 'fails with multiple origins')
+    DEBUG && console.log('right before git checkout ' + defaultBranch + ', fails with multiple origins')
     
     exec(`git checkout ${defaultBranch}`)
 


### PR DESCRIPTION
Fix a misunderstanding because Greenkeeper and GitLab define a "slug" differently.